### PR TITLE
Removing an unnecessary Kotlin extension.

### DIFF
--- a/core/src/main/kotlin/jahirfiquitiva/libs/kext/extensions/Kot.kt
+++ b/core/src/main/kotlin/jahirfiquitiva/libs/kext/extensions/Kot.kt
@@ -1,5 +1,1 @@
 package jahirfiquitiva.libs.kext.extensions
-
-inline fun <reified T> T?.notNull(what: (T) -> Unit) {
-    if (this != null) what(this)
-}


### PR DESCRIPTION
<!--
Any HTML comment will be stripped when the markdown is rendered, so you don't need to delete them.
-->

### Description
An equivalent to this function can be written as follows :

```kotlin
val a: Int? = null
val f: (Int) -> Unit by lazy { TODO("Provide an actual function.") }

// Uses some syntax of the standard library instead.
a?.apply(f)
```

### Motivation
Reusing some standard library functions might reduce the cognitive load when working with the code.